### PR TITLE
Secure http links (#5244)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1199,7 +1199,7 @@ All changes:
   from embedding into the binary. Those files are only used for debugging,
   and then you can use -web.use-local-assets. By including fewer files, the
   RAM usage during compilation is much more manageable.
-* [ENHANCEMENT] Help link points to http://prometheus.github.io now.
+* [ENHANCEMENT] Help link points to https://prometheus.github.io now.
 * [FEATURE] Consoles for haproxy and cloudwatch.
 * [BUGFIX] Several fixes to graphs in consoles.
 * [CLEANUP] Removed a file size check that did not check anything.

--- a/documentation/examples/kubernetes-rabbitmq/README.md
+++ b/documentation/examples/kubernetes-rabbitmq/README.md
@@ -12,7 +12,7 @@ With this pod running you will have the exporter scraping data, but Prometheus h
 yet found the exporter and is not scraping data from it.
 
 For more details on how to use Kubernetes service discovery take a look at the 
-[documentation](http://prometheus.io/docs/operating/configuration/#kubernetes-sd-configurations-kubernetes_sd_config)
+[documentation](https://prometheus.io/docs/operating/configuration/#kubernetes-sd-configurations-kubernetes_sd_config)
 and at the [available examples](./../).
 
 After you got Kubernetes service discovery up and running you just need to advertise that RabbitMQ


### PR DESCRIPTION
Fix http link to https link for secure, modify http to https
in the links of project. Have some http links doesn't
redirect into https.

Co-Authored-By: Nguyen Van Trung trungnv@vn.fujitsu.com
Signed-off-by: Nguyen Hai Truong <truongnh@vn.fujitsu.com>